### PR TITLE
Import hoomd and hoomd.md first to avoid linking issues.

### DIFF
--- a/metadynamics/integrate.py
+++ b/metadynamics/integrate.py
@@ -20,10 +20,10 @@ in the presence of a previously generated bias potential,
 without updating the latter, to sample a histogram of values of the
 collective variable (i.e. for error control).
 """
-from hoomd.metadynamics import _metadynamics
-from hoomd.metadynamics import cv
 import hoomd
 from hoomd import md
+from hoomd.metadynamics import _metadynamics
+from hoomd.metadynamics import cv
 
 
 class mode_metadynamics(md.integrate._integrator):


### PR DESCRIPTION
This minor change allows me to import the plugin without triggering a *undefined symbol* error when I don't explicitly import the `hoomd` and `hoomd.md` package first.